### PR TITLE
fix: Allows hash (`#`) in URL regexes

### DIFF
--- a/src/data/lexicon.json
+++ b/src/data/lexicon.json
@@ -45,7 +45,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -204,7 +204,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -372,7 +372,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -523,7 +523,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -843,7 +843,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -1423,7 +1423,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -1595,7 +1595,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -4180,7 +4180,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -7500,7 +7500,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -8884,7 +8884,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -9724,7 +9724,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -9932,7 +9932,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -13021,7 +13021,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -15027,7 +15027,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -16075,7 +16075,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -17343,7 +17343,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -17644,7 +17644,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -18822,7 +18822,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -19585,7 +19585,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -19731,7 +19731,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -19911,7 +19911,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -21376,7 +21376,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -22369,7 +22369,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -22494,7 +22494,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -24214,7 +24214,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -24432,7 +24432,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -24536,7 +24536,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",
@@ -25381,7 +25381,7 @@
               "type": "string",
               "required": true,
               "comment": "The URL endpoint for the request.",
-              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)*$"
+              "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/[#a-zA-Z0-9._-]+)*$"
             },
             "headers": {
               "type": "object",


### PR DESCRIPTION
fix: Allows hash (`#`) in URL regexes. For example - `https://gis.hcpafl.org/propertysearch/#/parcel/basic/153323ZZZ000000000200A`