### PR TITLE
ci: separate schema validation from publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,10 @@ on:
   pull_request:
     branches: [main, develop]
 
-env:
-  PINATA_JWT: ${{ secrets.PINATA_JWT }}
+# Pull request validation intentionally omits PINATA_JWT. The existing build
+# generates schemas locally when the token is absent and performs no remote writes.
+permissions:
+  contents: read
 
 jobs:
   lint-and-format:

--- a/.github/workflows/publish-schemas.yml
+++ b/.github/workflows/publish-schemas.yml
@@ -1,0 +1,45 @@
+name: Publish JSON Schemas
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-json-schemas
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish schemas to IPFS
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Supplying PINATA_JWT activates the generator's existing IPFS upload path.
+      # Keep the secret scoped to this explicit publication step only.
+      - name: Generate and publish schemas
+        env:
+          PINATA_JWT: ${{ secrets.PINATA_JWT }}
+        run: |
+          if [ -z "${PINATA_JWT:-}" ]; then
+            echo "::error::PINATA_JWT repository secret is not configured"
+            exit 1
+          fi
+
+          npm run build


### PR DESCRIPTION
## Summary
- keep ordinary pull request builds local-only by removing the workflow-level `PINATA_JWT`
- add a manual schema-publication workflow whose publish step alone receives the Pinata secret
- fail publication immediately when the secret is missing and retain upload failures from the existing generator
- restrict both workflows to read-only repository contents

## Why
PR #173 currently fails before its tests because pull request CI performs remote Pinata writes and the configured account returns `403 ACCOUNT_DISABLED`. Pull request validation only needs the generator's supported no-token mode and tracked static fixtures; remote publication should be an explicit release operation, not a side effect of every PR build.

No tag trigger was added because this repository currently has no release workflow or tag-based publication convention.

## Test plan
- [x] `env -u PINATA_JWT npm run build`
- [x] `npm run test:coverage` (361 tests)
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npx tsc --noEmit`
- [x] parse both workflow files as YAML
- [x] verify `.github/workflows/ci.yml` contains no Pinata secret or environment assignment

Related: #173

Made with [Cursor](https://cursor.com)